### PR TITLE
[nasa/nos3#519] Adjusting the cmdbus_bridge to use cmdbus-bridge instead

### DIFF
--- a/src/sim_cmdbus_bridge.cpp
+++ b/src/sim_cmdbus_bridge.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
 {
     signal(SIGINT, signal_handler);
 
-    std::string simulator_name = "cmdbus_bridge";
+    std::string simulator_name = "cmdbus-bridge";
 
     // Determine the configuration and run the simulator
     sim_cfg = new Nos3::SimConfig(argc, argv);


### PR DESCRIPTION
Submodule of https://github.com/nasa/nos3/pull/701